### PR TITLE
Update retrieving-data-and-resultsets.rst

### DIFF
--- a/en/orm/retrieving-data-and-resultsets.rst
+++ b/en/orm/retrieving-data-and-resultsets.rst
@@ -563,6 +563,17 @@ associations and filter them by conditions::
                 ->where(['Comments.approved' => true]);
         }
     ]);
+    
+To pass in a variable that is outside of the scope of the contain closure you should utilize the ```use``` identifier
+    
+    $query = $articles->find()->contain([
+        'Comments' => function ($q) use ($type) {
+           return $q
+                ->select(['body', 'author_id'])
+                ->where(['Comments.type' => $type]);
+        }
+    ]);
+
 
 This also works for pagination at the Controller level::
 


### PR DESCRIPTION
Added closure variable scope example as contain is likely one of the most widely used examples and this is different to previous versions. I'm not sure if this example is good enough for it but feel free to change